### PR TITLE
Remove [testenv:venv] now that `tox --devenv` is a thing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ matrix:
         -   env: TOXENV=py36
             python: 3.6
         -   env: TOXENV=pypy
-            python: pypy-5.7.1
+            python: pypy
 install: pip install coveralls tox
 script: tox
 after_success: TOP=. coveralls

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,4 @@
 [tox]
-project = tox_pip_extensions
 # These should match the travis env list
 envlist = py27,py35,py36,pypy
 
@@ -14,10 +13,6 @@ commands =
     coverage report --show-missing --fail-under 100
     pre-commit install -f --install-hooks
     pre-commit run --all-files
-
-[testenv:venv]
-envdir = venv-{[tox]project}
-commands =
 
 [pep8]
 ignore = E265,E309,E501


### PR DESCRIPTION
Committed via https://github.com/asottile/all-repos